### PR TITLE
Initialize git prompt state on theme setup

### DIFF
--- a/zsh/prompt_oligaymond_setup
+++ b/zsh/prompt_oligaymond_setup
@@ -161,6 +161,14 @@ prompt_oligaymond_setup() {
   add-zsh-hook chpwd title_prompt
   add-zsh-hook chpwd git_check_if_worktree
 
+  # Ensure the git prompt is initialised for the current directory before the
+  # first precmd hook runs. Without this, shells started inside a git
+  # repository (for example via tools that spawn a subshell such as
+  # ``pipenv shell``) would not display the branch name until the first
+  # directory change triggered the ``chpwd`` hook.
+  git_check_if_worktree
+  git_status
+
   if [ -z $SSH_TTY ]; then
       ZSSH=
   else


### PR DESCRIPTION
## Summary
- initialize the git prompt state during prompt setup so that shells started inside repositories immediately show the branch name

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ddacb7848325b55d6ab21ca392da